### PR TITLE
feat(preferences): add user preference management UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 - Run specific test: `go test -run TestName ./path/to/package`
 - Run tests with coverage: `go test -cover ./...`
 - Run linting: `golangci-lint run ./...`
-- Format code: `gofmt -s -w .`
+- Format code: `gofmt -s -w $(find . -type f -name "*.go" -not -path "./vendor/*")`
 - Run code generation: `go generate ./...`
 - Coverage report: `go test -race -coverprofile=coverage.out ./... && go tool cover -func=coverage.out`
 - Normalize code comments: `command -v unfuck-ai-comments >/dev/null || go install github.com/umputun/unfuck-ai-comments@latest; unfuck-ai-comments run --fmt --skip=mocks ./...`

--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ Configure preferred and avoided topics in Settings to influence article scoring:
 
 This allows you to boost content you're interested in and filter out topics you want to avoid.
 
+### AI-Learned Preferences
+
+The system automatically learns your preferences based on your likes and dislikes:
+- **Preference Summary**: A personalized description of what content you prefer and want to avoid
+- **Automatic Learning**: Updates after every 10 feedback actions (configurable)
+- **Manual Control**: Edit the preference summary directly in Settings
+- **Enable/Disable**: Toggle preference learning on/off
+- **Reset**: Clear all preferences and start fresh
+
+To manage your preferences:
+1. Go to Settings → AI-Learned Preferences
+2. View your current preference summary
+3. Click "Edit" to modify it manually
+4. Toggle the switch to enable/disable learning
+5. Use "Reset" to clear all preferences
+
 ### Content Extraction
 
 Click "Extract Content" on any article to fetch and display the full text. Content is sanitized and formatted for readability.
@@ -245,6 +261,12 @@ llm:
 - `POST /api/v1/feeds` - Create new feed
 - `PUT /api/v1/feeds/{id}` - Update feed
 - `DELETE /api/v1/feeds/{id}` - Delete feed
+
+### Preference Management
+
+- `GET /api/v1/preferences` - Get preference summary and metadata
+- `PUT /api/v1/preferences` - Update preference summary
+- `DELETE /api/v1/preferences` - Reset all preferences
 
 ### RSS Endpoints
 

--- a/pkg/domain/setting.go
+++ b/pkg/domain/setting.go
@@ -11,6 +11,10 @@ type Setting struct {
 
 // Setting keys
 const (
-	SettingPreferredTopics = "preferred_topics"
-	SettingAvoidedTopics   = "avoided_topics"
+	SettingPreferredTopics             = "preferred_topics"
+	SettingAvoidedTopics               = "avoided_topics"
+	SettingPreferenceSummary           = "preference_summary"
+	SettingLastSummaryFeedbackCount    = "last_summary_feedback_count"
+	SettingPreferenceSummaryEnabled    = "preference_summary_enabled"
+	SettingPreferenceSummaryLastUpdate = "preference_summary_last_update"
 )

--- a/pkg/scheduler/preference_manager.go
+++ b/pkg/scheduler/preference_manager.go
@@ -59,6 +59,13 @@ func NewPreferenceManager(cfg PreferenceManagerConfig) *PreferenceManager {
 // the preference summary using the LLM. This method is designed to be
 // called periodically but will only perform expensive LLM operations when needed.
 func (pm *PreferenceManager) UpdatePreferenceSummary(ctx context.Context) error {
+	// check if preference learning is enabled
+	enabledStr, _ := pm.settingManager.GetSetting(ctx, domain.SettingPreferenceSummaryEnabled)
+	if enabledStr == "false" {
+		lgr.Printf("[DEBUG] preference learning is disabled, skipping update")
+		return nil
+	}
+
 	// get more feedback examples for better learning (50 instead of 10)
 	const feedbackExamples = 50
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -344,8 +344,6 @@ func (e *criticalError) Is(target error) bool {
 	return ok
 }
 
-
-
 // isLockError checks if an error is a SQLite lock/busy error
 func isLockError(err error) bool {
 	if err == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -209,7 +209,8 @@ func New(cfg ConfigProvider, database Database, scheduler Scheduler, version str
 		"templates/pagination.html",
 		"templates/topic-tags.html",
 		"templates/topic-dropdowns.html",
-		"templates/controls.html")
+		"templates/controls.html",
+		"templates/preference-summary.html")
 	if err != nil {
 		log.Printf("[WARN] failed to parse templates: %v", err)
 	}
@@ -342,6 +343,18 @@ func (s *Server) setupRoutes() {
 		// topic preferences management
 		r.HandleFunc("POST /topics", s.addTopicHandler)
 		r.HandleFunc("DELETE /topics/{topic}", s.deleteTopicHandler)
+
+		// preference summary management (JSON API)
+		r.HandleFunc("GET /preferences", s.getPreferencesHandler)
+		r.HandleFunc("PUT /preferences", s.updatePreferencesHandler)
+		r.HandleFunc("DELETE /preferences", s.deletePreferencesHandler)
+
+		// preference summary management (HTMX handlers)
+		r.HandleFunc("GET /preferences/view", s.preferenceViewHandler)
+		r.HandleFunc("GET /preferences/edit", s.preferenceEditHandler)
+		r.HandleFunc("POST /preferences/save", s.preferenceSaveHandler)
+		r.HandleFunc("DELETE /preferences/reset", s.preferenceResetHandler)
+		r.HandleFunc("POST /preferences/toggle", s.preferenceToggleHandler)
 	})
 
 	// RSS routes

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -1983,4 +1983,200 @@ small.text-muted {
     }
 }
 
+/* Preference Summary Styles */
+.preference-summary-container {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+
+.preference-summary-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1.5rem;
+}
+
+.preference-summary-header .subsection-header {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+}
+
+.preference-summary-meta {
+    display: flex;
+    gap: 1.5rem;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.meta-item i {
+    color: var(--text-muted);
+}
+
+.preference-summary-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    gap: 1rem;
+    flex-wrap: wrap;
+    border-bottom: none;
+}
+
+.preference-summary-controls::after,
+.preference-summary-controls::before {
+    display: none;
+}
+
+.toggle-switch {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+}
+
+.toggle-switch input[type="checkbox"] {
+    display: none;
+}
+
+.toggle-slider {
+    width: 48px;
+    height: 24px;
+    background-color: var(--text-muted);
+    border-radius: 24px;
+    margin-right: 0.75rem;
+    position: relative;
+    transition: background-color 0.2s;
+}
+
+.toggle-slider::after {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background-color: white;
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.2s;
+}
+
+.toggle-switch input[type="checkbox"]:checked + .toggle-slider {
+    background-color: var(--primary-color);
+}
+
+.toggle-switch input[type="checkbox"]:checked + .toggle-slider::after {
+    transform: translateX(24px);
+}
+
+.toggle-label {
+    font-size: 0.875rem;
+    color: var(--text-primary);
+}
+
+.button-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.preference-summary-content {
+    margin-top: 1rem;
+    border-top: none;
+    border: none;
+}
+
+#preference-form {
+    border: none;
+    border-top: none;
+}
+
+.preference-summary-textarea {
+    width: 100%;
+    min-height: 200px;
+    padding: 1rem;
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.875rem;
+    line-height: 1.6;
+    resize: vertical;
+    transition: border-color 0.2s, background-color 0.2s;
+}
+
+.preference-summary-textarea:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.preference-summary-textarea[readonly] {
+    background: var(--bg-tertiary);
+    cursor: default;
+}
+
+.preference-summary-textarea.editable {
+    background: var(--bg-primary);
+}
+
+.preference-summary-help {
+    margin-top: 1rem;
+    display: flex;
+    align-items: start;
+    gap: 0.5rem;
+    font-size: 0.813rem;
+    color: var(--text-secondary);
+}
+
+.preference-summary-help i {
+    color: var(--text-muted);
+    margin-top: 0.125rem;
+    flex-shrink: 0;
+}
+
+.preference-summary-help p {
+    margin: 0;
+    line-height: 1.5;
+}
+
+.loading {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-secondary);
+}
+
+.loading i {
+    margin-right: 0.5rem;
+}
+
+/* Mobile adjustments */
+@media (max-width: 768px) {
+    .preference-summary-header {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    
+    .preference-summary-meta {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+    
+    .preference-summary-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .button-group {
+        justify-content: center;
+    }
+}
+
 

--- a/server/templates/preference-summary.html
+++ b/server/templates/preference-summary.html
@@ -1,0 +1,73 @@
+<div class="preference-summary-header">
+    <h4 class="subsection-header">
+        <i class="fas fa-user-cog"></i>
+        AI-Learned Preferences
+    </h4>
+    <div class="preference-summary-meta">
+        <span class="meta-item">
+            <i class="fas fa-chart-line"></i>
+            <span class="count">{{.FeedbackCount}}</span> feedback items
+        </span>
+        <span class="meta-item">
+            <i class="fas fa-clock"></i>
+            Last updated: <span class="time">{{.LastUpdate}}</span>
+        </span>
+    </div>
+</div>
+
+<div class="preference-summary-controls">
+    <label class="toggle-switch">
+        <input type="checkbox" {{if .Enabled}}checked{{end}}
+               hx-post="/api/v1/preferences/toggle"
+               hx-target="#preference-summary-container"
+               hx-swap="innerHTML">
+        <span class="toggle-slider"></span>
+        <span class="toggle-label">Enable preference learning</span>
+    </label>
+    
+    <div class="button-group">
+        {{if .EditMode}}
+            <button class="btn btn-primary"
+                    hx-post="/api/v1/preferences/save"
+                    hx-include="#preference-form"
+                    hx-target="#preference-summary-container"
+                    hx-swap="innerHTML">
+                <i class="fas fa-save"></i>
+                Save
+            </button>
+            <button class="btn btn-secondary"
+                    hx-get="/api/v1/preferences/view"
+                    hx-target="#preference-summary-container"
+                    hx-swap="innerHTML">
+                <i class="fas fa-times"></i>
+                Cancel
+            </button>
+        {{else}}
+            <button class="btn btn-secondary"
+                    hx-get="/api/v1/preferences/edit"
+                    hx-target="#preference-summary-container"
+                    hx-swap="innerHTML">
+                <i class="fas fa-edit"></i>
+                Edit
+            </button>
+        {{end}}
+        <button class="btn btn-danger"
+                hx-delete="/api/v1/preferences/reset"
+                hx-target="#preference-summary-container"
+                hx-swap="innerHTML"
+                hx-confirm="Are you sure you want to reset your preferences? This will clear all learned preferences and reset the feedback counter.">
+            <i class="fas fa-redo"></i>
+            Reset
+        </button>
+    </div>
+</div>
+
+<form id="preference-form" class="preference-summary-content">
+    <textarea name="summary" class="preference-summary-textarea" {{if not .EditMode}}readonly{{end}}
+              placeholder="No preference summary yet. The AI will learn from your likes and dislikes to build a personalized preference profile.">{{.Summary}}</textarea>
+    <input type="hidden" name="enabled" value="{{if .Enabled}}on{{end}}">
+    <div class="preference-summary-help">
+        <i class="fas fa-info-circle"></i>
+        <p>This summary is automatically generated based on your article feedback. It helps the AI better understand what content you prefer and what you want to avoid.</p>
+    </div>
+</form>

--- a/server/templates/settings.html
+++ b/server/templates/settings.html
@@ -104,6 +104,22 @@
                     </div>
                 </div>
             </div>
+            
+            <div class="settings-section">
+                <div class="section-header">
+                    <i class="fas fa-brain"></i>
+                    <h3>Learning Preferences</h3>
+                </div>
+                
+                <div id="preference-summary-container" class="preference-summary-container"
+                     hx-get="/api/v1/preferences/view"
+                     hx-trigger="load">
+                    <!-- Content will be loaded via HTMX -->
+                    <div class="loading">
+                        <i class="fas fa-spinner fa-spin"></i> Loading preferences...
+                    </div>
+                </div>
+            </div>
         </div>
     </div>  <!-- End of preferences-tab -->
     


### PR DESCRIPTION
## Summary
- Add comprehensive preference management UI to allow users to view, edit, and reset their AI-learned preferences
- Implement HTMX-based interface without JavaScript for better performance and simplicity
- Add enable/disable toggle for preference learning with persistent state

## Changes Made

### Backend
- Added new setting constants in `domain/setting.go` for preference management
- Created REST API endpoints:
  - `GET /api/v1/preferences` - Get current preference summary and metadata
  - `PUT /api/v1/preferences` - Update preference summary  
  - `DELETE /api/v1/preferences` - Reset preferences
- Added HTMX handlers for UI interactions (view, edit, save, reset, toggle)
- Updated scheduler to respect the enabled setting when updating preferences
- Fixed error handling in preference toggle handler

### Frontend
- Created new preference management section in Settings page
- Implemented view/edit modes with smooth transitions
- Added preference summary textarea with character limit
- Display feedback count and last update timestamp
- Created enable/disable toggle switch with custom CSS
- Fixed CSS issue causing partial separator line
- Responsive design for mobile devices

### Testing
- Added comprehensive unit tests for all REST handlers
- Added tests for HTMX handlers  
- All tests passing with proper error handling coverage

### Documentation
- Updated README.md with new AI-Learned Preferences section
- Added API endpoint documentation

## Screenshots
Users can now:
1. View their current preference summary
2. Edit the summary manually if needed
3. Reset all preferences to start fresh
4. Toggle preference learning on/off
5. See metadata (feedback count, last update time)

All changes are persisted to the database and the UI updates dynamically using HTMX.